### PR TITLE
bugfix: same values in a row is ignored

### DIFF
--- a/addon/components/grid-nx.js
+++ b/addon/components/grid-nx.js
@@ -49,7 +49,7 @@ export default Ember.Component.extend({
     filteredContent.forEach(function(item){
       var row = Ember.A();
       attrs.forEach(function(attr){
-        row.addObject(item.get(attr));
+        row.pushObject(item.get(attr));
       });
       rows.pushObject(row);
     });


### PR DESCRIPTION
Hi, I met a problem on grid-nx, on my own project using it.

The problem is, if a row has two or more column with same value, it completely ignored.
as a result, some `<td></td>` is not generated and table is broken like below:

```
<tr><td>speak</td><td>spoke</td></tr>
<tr><td>read</td></tr>
```

(data is: speak, spoke; read, read)

so I changed addObject() to pushObject().
please merge this to your main repo.
